### PR TITLE
AUTOPAY-21861 Binary-wrapped Fields

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @Visma-AutoPay/autopay-developers

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,8 @@ pipeline {
     }
 
     environment {
-        MAIN_BUILD_GOAL = 'package'
-        BRANCH_BUILD_GOAL = 'package sonar:sonar'
+        MAIN_BUILD_GOAL = 'verify'
+        BRANCH_BUILD_GOAL = 'verify sonar:sonar'
     }
 
     tools {

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ authenticity for components of an HTTP message.
 
 This library provides a high-level Java interface for creating and verifying
 signatures as defined in the
-[HTTP Message Signatures specification](https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html)
-(draft 10). As by-products, it implements
+[HTTP Message Signatures specification](https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html)
+(draft 11). As by-products, it implements
 [Digest Fields](https://www.ietf.org/archive/id/draft-ietf-httpbis-digest-headers-10.html)
 (draft 10) and
 [Structured Field Values for HTTP](https://www.rfc-editor.org/rfc/rfc8941).
@@ -37,7 +37,7 @@ and `Signature` headers.
 included, what key is used
 - `Signature` - Concatenated request parts defined in the input are signed by
 using the referenced key. Both Signature-Input and Signature are defined by
-[HTTP Message Signatures](https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html).
+[HTTP Message Signatures](https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html).
 - Syntax - Those headers are formatted by using the syntax of
 [Structured Field Values for HTTP](https://www.rfc-editor.org/rfc/rfc8941)
 
@@ -413,7 +413,7 @@ Support for Edwards-Curve signatures (`SignatureAlgorithm.ED_25519`, `Ed25519`)
 was added to JRE in Java 15. For older JREs, a third-party provider must be
 used.
 
-As [ECDSA signatures require IEEE P1363 format (raw)](https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-ecdsa-using-curve-p-256-dss),
+As [ECDSA signatures require IEEE P1363 format (raw)](https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-ecdsa-using-curve-p-256-dss),
 algorithm `SHA256withECDSAinP1363Format` is used rather than `SHA256withECDSA`.
 If your provider uses a different name, like Bouncy Castle's
 `SHA256withPLAIN-ECDSA`, then a delegate must be implemented.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ var signatureComponents = SignatureComponents.builder()
         .canonicalizedHeader("My-Structured-Header")
         // Individual items of structured dictionary
         .dictionaryMember("My-Dictionary", "key-1")
+        // Multi-value header wrapped as structured byte sequences
+        .binaryWrappedHeader("Set-Cookie")
 
         // Single headers from related request, when signing response
         .relatedRequestHeader("Content-Type")

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk18on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/visma/autopay/http/signature/Component.java
+++ b/src/main/java/com/visma/autopay/http/signature/Component.java
@@ -64,6 +64,14 @@ abstract class Component {
      */
     protected static final String QUERY_PARAM_NAME_PARAM = "name";
 
+    /**
+     * Structures Parameter key for Binary-wrapped Fields
+     *
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-binary-wrapped-http-fields">
+     *      Binary-wrapped HTTP Fields</a>
+     */
+    protected static final String BINARY_WRAPPED_PARAM = "bs";
+
     private final StructuredString name;
 
     /**

--- a/src/main/java/com/visma/autopay/http/signature/Component.java
+++ b/src/main/java/com/visma/autopay/http/signature/Component.java
@@ -30,13 +30,13 @@ import java.util.Objects;
  * <p>
  * Backed by {@link StructuredString}. Contains component definition - value should be provided in {@link SignatureContext}
  *
- * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-message-components">HTTP Message Components</a>
+ * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-message-components">HTTP Message Components</a>
  */
 abstract class Component {
     /**
      * Structured Parameter key for Structured Dictionary members
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-dictionary-structured-field">
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-dictionary-structured-field">
      *      Dictionary Structured Field Members</a>
      */
     protected static final String DICTIONARY_KEY_PARAM = "key";
@@ -44,7 +44,7 @@ abstract class Component {
     /**
      * Structured Parameter key for Canonicalized fields
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-canonicalized-structured-ht">
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-canonicalized-structured-ht">
      *      Canonicalized Structured HTTP Fields</a>
      */
     protected static final String CANONICALIZED_FIELD_PARAM = "sf";
@@ -52,7 +52,7 @@ abstract class Component {
     /**
      * Structured Parameter key for components from Related Request
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
      *      Request-Response Signature Binding</a>
      */
     protected static final String RELATED_REQUEST_PARAM = "req";
@@ -60,7 +60,7 @@ abstract class Component {
     /**
      * Structured Parameter key for Query Param name
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-query-parameters">Query Parameters</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-query-parameters">Query Parameters</a>
      */
     protected static final String QUERY_PARAM_NAME_PARAM = "name";
 

--- a/src/main/java/com/visma/autopay/http/signature/DerivedComponent.java
+++ b/src/main/java/com/visma/autopay/http/signature/DerivedComponent.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 /**
  * Class representing Derived Components
  *
- * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-derived-components">Derived Components</a>
+ * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-derived-components">Derived Components</a>
  */
 final class DerivedComponent extends Component {
     private final DerivedComponentType componentType;

--- a/src/main/java/com/visma/autopay/http/signature/DerivedComponentType.java
+++ b/src/main/java/com/visma/autopay/http/signature/DerivedComponentType.java
@@ -28,76 +28,76 @@ import java.util.stream.Stream;
 /**
  * Defines types of Derived Components
  *
- * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-derived-components">Derived Components</a>
+ * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-derived-components">Derived Components</a>
  */
 enum DerivedComponentType {
     /**
      * &#64;signature-params - the signature metadata parameters
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#signature-params">Signature Parameters</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#signature-params">Signature Parameters</a>
      */
     SIGNATURE_PARAMS("@signature-params"),
 
     /**
      * &#64;method - the method used for a request
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-method">Method</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-method">Method</a>
      */
     METHOD("@method"),
 
     /**
      * &#64;target-uri - the full target URI for a request
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-target-uri">Target URI</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-target-uri">Target URI</a>
      */
     TARGET_URI("@target-uri"),
 
     /**
      * &#64;authority - the authority (host) of the target URI for a request
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-authority">Authority</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-authority">Authority</a>
      */
     AUTHORITY("@authority"),
 
     /**
      * &#64;scheme - the scheme of the target URI for a request
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-scheme">Scheme</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-scheme">Scheme</a>
      */
     SCHEME("@scheme"),
 
     /**
      * &#64;request-target - the request target
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-target">Request Target</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-target">Request Target</a>
      */
     REQUEST_TARGET("@request-target"),
 
     /**
      * &#64;path - the absolute path portion of the target URI for a request
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-path">Path</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-path">Path</a>
      */
     PATH("@path"),
 
     /**
      * &#64;query - the query portion of the target URI for a request
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-query">Query</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-query">Query</a>
      */
     QUERY("@query"),
 
     /**
      * &#64;query-param - a parsed query parameter of the target URI for a request
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-query-param">Query Parameters</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-query-param">Query Parameters</a>
      */
     QUERY_PARAM("@query-param"),
 
     /**
      * &#64;status - the status code for a response
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-status-code">Status Code</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-status-code">Status Code</a>
      */
     STATUS("@status"),
     ;

--- a/src/main/java/com/visma/autopay/http/signature/HeaderComponent.java
+++ b/src/main/java/com/visma/autopay/http/signature/HeaderComponent.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  * Both "plain" headers, canonicalized fields and dictionary field members are represented.
  * From both "this" and "related" request.
  *
- * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-fields">HTTP Fields</a>
+ * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-fields">HTTP Fields</a>
  */
 final class HeaderComponent extends Component {
     private final String headerName;

--- a/src/main/java/com/visma/autopay/http/signature/HeaderComponent.java
+++ b/src/main/java/com/visma/autopay/http/signature/HeaderComponent.java
@@ -22,13 +22,18 @@
 package com.visma.autopay.http.signature;
 
 import com.visma.autopay.http.signature.SignatureException.ErrorCode;
+import com.visma.autopay.http.structured.StructuredBytes;
 import com.visma.autopay.http.structured.StructuredDictionary;
 import com.visma.autopay.http.structured.StructuredException;
 import com.visma.autopay.http.structured.StructuredField;
+import com.visma.autopay.http.structured.StructuredItem;
 import com.visma.autopay.http.structured.StructuredString;
 
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Class representing HTTP Fields (Headers) Component
@@ -42,6 +47,7 @@ final class HeaderComponent extends Component {
     private final String headerName;
     private final String dictionaryKey;
     private final boolean canonicalized;
+    private final boolean binaryWrapped;
 
     /**
      * Creates a Header Component of given header name
@@ -53,6 +59,7 @@ final class HeaderComponent extends Component {
         this.headerName = headerName;
         this.dictionaryKey = null;
         this.canonicalized = false;
+        this.binaryWrapped = false;
     }
 
     /**
@@ -62,12 +69,14 @@ final class HeaderComponent extends Component {
      * @param dictionaryKey      Dictionary key for Dictionary Structured Field Members
      * @param canonicalized      True for Canonicalized Structured HTTP Fields
      * @param fromRelatedRequest True if component is from related request
+     * @param binaryWrapped      True if header values need to be wrapped as binary structures
      */
-    HeaderComponent(String headerName, String dictionaryKey, boolean canonicalized, boolean fromRelatedRequest) {
-        super(getStructuredName(headerName, dictionaryKey, canonicalized, fromRelatedRequest));
+    HeaderComponent(String headerName, String dictionaryKey, boolean canonicalized, boolean fromRelatedRequest, boolean binaryWrapped) {
+        super(getStructuredName(headerName, dictionaryKey, canonicalized, fromRelatedRequest, binaryWrapped));
         this.headerName = headerName;
         this.dictionaryKey = dictionaryKey;
         this.canonicalized = canonicalized;
+        this.binaryWrapped = binaryWrapped;
 
         if (dictionaryKey != null && dictionaryKey.isEmpty()) {
             throw new IllegalArgumentException("Invalid dictionary key: " + dictionaryKey);
@@ -84,9 +93,11 @@ final class HeaderComponent extends Component {
         this.headerName = structuredHeader.stringValue();
         this.dictionaryKey = structuredHeader.stringParam(DICTIONARY_KEY_PARAM).orElse(null);
         this.canonicalized = structuredHeader.boolParam(CANONICALIZED_FIELD_PARAM).orElse(false);
+        this.binaryWrapped = structuredHeader.boolParam(BINARY_WRAPPED_PARAM).orElse(false);
     }
 
-    private static StructuredString getStructuredName(String headerName, String dictionaryKey, boolean canonicalized, boolean fromRelatedRequest) {
+    private static StructuredString getStructuredName(String headerName, String dictionaryKey, boolean canonicalized, boolean fromRelatedRequest,
+                                                      boolean binaryWrapped) {
         var params = new LinkedHashMap<String, Object>();
 
         if (fromRelatedRequest) {
@@ -101,24 +112,37 @@ final class HeaderComponent extends Component {
             params.put(DICTIONARY_KEY_PARAM, dictionaryKey);
         }
 
+        if (binaryWrapped) {
+            params.put(BINARY_WRAPPED_PARAM, true);
+        }
+
         return StructuredString.withParams(headerName, params);
     }
 
     @Override
     String computeValue(SignatureContext signatureContext) throws SignatureException {
-        var headerValue = signatureContext.getHeaders().get(headerName);
+        var headerValues = signatureContext.getHeaders().get(headerName);
+        String computedValue;
 
-        if (headerValue == null) {
+        if (headerValues == null) {
             throw new SignatureException(ErrorCode.MISSING_HEADER, "Header " + headerName + " is missing");
         }
 
-        if (dictionaryKey != null) {
-            return getDictionaryMember(headerValue);
-        } else if (canonicalized) {
-            return getCanonicalized(headerValue);
+        if (binaryWrapped) {
+            computedValue = getBinaryWrapped(headerValues);
         } else {
-            return headerValue;
+            var headerValue = getSingleValue(headerValues);
+
+            if (dictionaryKey != null) {
+                computedValue =  getDictionaryMember(headerValue);
+            } else if (canonicalized) {
+                computedValue =  getCanonicalized(headerValue);
+            } else {
+                computedValue =  headerValue;
+            }
         }
+
+        return computedValue;
     }
 
     @Override
@@ -131,12 +155,19 @@ final class HeaderComponent extends Component {
             return true;
         } else {
             try {
-                getDictionaryMember(headerValue);
+                getDictionaryMember(getSingleValue(headerValue));
                 return true;
             } catch (SignatureException e) {
                 return e.getErrorCode() != ErrorCode.MISSING_DICTIONARY_KEY;
             }
         }
+    }
+
+    private String getBinaryWrapped(List<String> headerValues) {
+        return headerValues.stream()
+                .map(value -> StructuredBytes.of(value.getBytes(StandardCharsets.UTF_8)))
+                .map(StructuredItem::serialize)
+                .collect(Collectors.joining(", "));
     }
 
     private String getCanonicalized(String headerValue) throws SignatureException {
@@ -163,6 +194,20 @@ final class HeaderComponent extends Component {
         } else {
             throw new SignatureException(ErrorCode.MISSING_DICTIONARY_KEY, "Key " + dictionaryKey + " is missing in header " + headerName);
         }
+    }
+
+    private String getSingleValue(List<String> headerValues) {
+        String headerValue;
+
+        if (headerValues.size() == 1) {
+            headerValue = headerValues.get(0);
+        } else {
+            headerValue = headerValues.stream()
+                    .filter(value -> !value.isEmpty())
+                    .collect(Collectors.joining(", "));
+        }
+
+        return headerValue;
     }
 
     @Override

--- a/src/main/java/com/visma/autopay/http/signature/SignatureAlgorithm.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureAlgorithm.java
@@ -32,21 +32,21 @@ import java.util.stream.Stream;
 /**
  * Signature algorithms
  *
- * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-signature-algorithms-r">
+ * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-signature-algorithms-r">
  *      HTTP Signature Algorithms Registry</a>
  */
 public enum SignatureAlgorithm {
     /**
      * RSASSA-PSS using SHA-512
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-rsassa-pss-using-sha-512">RSASSA-PSS using SHA-512</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-rsassa-pss-using-sha-512">RSASSA-PSS using SHA-512</a>
      */
     RSA_PSS_SHA_512("rsa-pss-sha512", "RSASSA-PSS", SignatureKeyAlgorithm.RSA, new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 64, 1)),
 
     /**
      * RSASSA-PKCS1-v1_5 using SHA-256
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-rsassa-pkcs1-v1_5-using-sha">
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-rsassa-pkcs1-v1_5-using-sha">
      *      RSASSA-PKCS1-v1_5 using SHA-256</a>
      */
     RSA_SHA_256("rsa-v1_5-sha256", "SHA256withRSA", SignatureKeyAlgorithm.RSA),
@@ -54,14 +54,14 @@ public enum SignatureAlgorithm {
     /**
      * HMAC using SHA-256
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-hmac-using-sha-256">HMAC using SHA-256</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-hmac-using-sha-256">HMAC using SHA-256</a>
      */
     HMAC_SHA_256("hmac-sha256", "HmacSHA256", SignatureKeyAlgorithm.HMAC),
 
     /**
      * ECDSA using curve P-256 DSS and SHA-256
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-ecdsa-using-curve-p-256-dss">
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-ecdsa-using-curve-p-256-dss">
      *      ECDSA using curve P-256 DSS and SHA-256</a>
      */
     ECDSA_P256_SHA_256("ecdsa-p256-sha256", "SHA256withECDSAinP1363Format", SignatureKeyAlgorithm.EC),
@@ -69,7 +69,7 @@ public enum SignatureAlgorithm {
     /**
      * Edwards Curve DSA using curve edwards25519
      *
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-eddsa-using-curve-edwards25">
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-eddsa-using-curve-edwards25">
      *      EdDSA using curve edwards25519</a>
      */
     ED_25519("ed25519", "Ed25519", SignatureKeyAlgorithm.ED_25519),
@@ -102,7 +102,7 @@ public enum SignatureAlgorithm {
      *
      * @param identifier Algorithm identifier
      * @return Created SignatureAlgorithm
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-initial-contents">
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-initial-contents">
      *      Algorithm names in the Algorithms Registry</a>
      */
     static SignatureAlgorithm fromIdentifier(String identifier) {

--- a/src/main/java/com/visma/autopay/http/signature/SignatureComponents.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureComponents.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Contains component definitions - values should be provided in {@link SignatureContext}.
  * Internally, backed by a list of {@link Component} objects.
  *
- * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-message-components">HTTP Message Components</a>
+ * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-message-components">HTTP Message Components</a>
  * @see Component
  */
 public class SignatureComponents {
@@ -78,7 +78,7 @@ public class SignatureComponents {
          *
          * @param headerName Header name
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-fields">HTTP Fields</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-fields">HTTP Fields</a>
          * @see HeaderComponent
          */
         public Builder header(String headerName) {
@@ -91,7 +91,7 @@ public class SignatureComponents {
          *
          * @param headerNames Header names
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-fields">HTTP Fields</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-fields">HTTP Fields</a>
          * @see HeaderComponent
          */
         public Builder headers(Collection<String> headerNames) {
@@ -104,7 +104,7 @@ public class SignatureComponents {
          *
          * @param headerNames Header names
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-fields">HTTP Fields</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-fields">HTTP Fields</a>
          * @see HeaderComponent
          */
         public Builder headers(String... headerNames) {
@@ -119,8 +119,8 @@ public class SignatureComponents {
          *
          * @param headerName Header name from the related request
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-fields">HTTP Fields</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-fields">HTTP Fields</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>*
          * @see HeaderComponent
          */
@@ -134,7 +134,7 @@ public class SignatureComponents {
          *
          * @param headerName Header name
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-canonicalized-structured-ht">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-canonicalized-structured-ht">
          *      Canonicalized Structured HTTP Fields</a>
          * @see HeaderComponent
          */
@@ -148,9 +148,9 @@ public class SignatureComponents {
          *
          * @param headerName Header name
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-canonicalized-structured-ht">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-canonicalized-structured-ht">
          *      Canonicalized Structured HTTP Fields</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see HeaderComponent
          */
@@ -165,7 +165,7 @@ public class SignatureComponents {
          * @param headerName    Header name
          * @param dictionaryKey Dictionary member key
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-dictionary-structured-field">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-dictionary-structured-field">
          *      Dictionary Structured Field Members</a>
          * @see HeaderComponent
          */
@@ -180,9 +180,9 @@ public class SignatureComponents {
          * @param headerName    Header name
          * @param dictionaryKey Dictionary member key
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-dictionary-structured-field">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-dictionary-structured-field">
          *      Dictionary Structured Field Members</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see HeaderComponent
          */
@@ -211,7 +211,7 @@ public class SignatureComponents {
          * @return This builder
          * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-binary-wrapped-http-fields">
          *      Binary-wrapped HTTP Fields</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          */
         public Builder relatedRequestBinaryWrappedHeader(String headerName) {
@@ -233,7 +233,7 @@ public class SignatureComponents {
          * Adds a &#64;method derived component - the method used for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-method">Method</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-method">Method</a>
          * @see DerivedComponent
          */
         public Builder method() {
@@ -244,8 +244,8 @@ public class SignatureComponents {
          * Adds a &#64;method derived component for Related Request - the method used for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-method">Method</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-method">Method</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see DerivedComponent
          */
@@ -257,7 +257,7 @@ public class SignatureComponents {
          * Adds a &#64;target-uri derived component - the full target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-target-uri">Target URI</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-target-uri">Target URI</a>
          * @see DerivedComponent
          */
         public Builder targetUri() {
@@ -268,8 +268,8 @@ public class SignatureComponents {
          * Adds a &#64;target-uri derived component for Related Request - the full target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-target-uri">Target URI</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-target-uri">Target URI</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see DerivedComponent
          */
@@ -281,7 +281,7 @@ public class SignatureComponents {
          * Adds an &#64;authority derived component - the authority (host) of the target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-authority">Authority</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-authority">Authority</a>
          * @see DerivedComponent
          */
         public Builder authority() {
@@ -292,8 +292,8 @@ public class SignatureComponents {
          * Adds an &#64;authority derived component for Related Request - the authority (host) of the target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-authority">Authority</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-authority">Authority</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see DerivedComponent
          */
@@ -305,7 +305,7 @@ public class SignatureComponents {
          * Adds a &#64;scheme derived component - the scheme of the target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-scheme">Scheme</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-scheme">Scheme</a>
          * @see DerivedComponent
          */
         public Builder scheme() {
@@ -316,8 +316,8 @@ public class SignatureComponents {
          * Adds a &#64;scheme derived component for Related Request - the scheme of the target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-scheme">Scheme</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-scheme">Scheme</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see DerivedComponent
          */
@@ -329,7 +329,7 @@ public class SignatureComponents {
          * Adds a &#64;request-target derived component
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-target">Request Target</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-target">Request Target</a>
          * @see DerivedComponent
          */
         public Builder requestTarget() {
@@ -340,8 +340,8 @@ public class SignatureComponents {
          * Adds a &#64;request-target derived component for Related Request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-target">Request Target</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-target">Request Target</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see DerivedComponent
          */
@@ -353,7 +353,7 @@ public class SignatureComponents {
          * Adds a &#64;path derived component - the absolute path portion of the target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-path">Path</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-path">Path</a>
          * @see DerivedComponent
          */
         public Builder path() {
@@ -364,8 +364,8 @@ public class SignatureComponents {
          * Adds a &#64;path derived component for Related Request - the absolute path portion of the target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-path">Path</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-path">Path</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see DerivedComponent
          */
@@ -377,7 +377,7 @@ public class SignatureComponents {
          * Adds a &#64;query derived component - the query portion of the target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-query">Query</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-query">Query</a>
          * @see DerivedComponent
          */
         public Builder query() {
@@ -388,8 +388,8 @@ public class SignatureComponents {
          * Adds a &#64;query derived component for Related Request - the query portion of the target URI for a request
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-query">Query</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-query">Query</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see DerivedComponent
          */
@@ -402,7 +402,7 @@ public class SignatureComponents {
          *
          * @param paramName Query parameter name
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-query-param">Query Parameters</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-query-param">Query Parameters</a>
          * @see DerivedComponent
          */
         public Builder queryParam(String paramName) {
@@ -415,8 +415,8 @@ public class SignatureComponents {
          *
          * @param paramName Query parameter name
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-request-query-param">Query Parameters</a>
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-request-query-param">Query Parameters</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
          *      Request-Response Signature Binding</a>
          * @see DerivedComponent
          */
@@ -429,7 +429,7 @@ public class SignatureComponents {
          * Adds a &#64;status derived component - the status code for a response
          *
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#content-status-code">Status Code</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#content-status-code">Status Code</a>
          * @see DerivedComponent
          */
         public Builder status() {

--- a/src/main/java/com/visma/autopay/http/signature/SignatureComponents.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureComponents.java
@@ -125,7 +125,7 @@ public class SignatureComponents {
          * @see HeaderComponent
          */
         public Builder relatedRequestHeader(String headerName) {
-            components.add(new HeaderComponent(headerName.toLowerCase(), null, false, true));
+            components.add(new HeaderComponent(headerName.toLowerCase(), null, false, true, false));
             return this;
         }
 
@@ -139,7 +139,7 @@ public class SignatureComponents {
          * @see HeaderComponent
          */
         public Builder canonicalizedHeader(String headerName) {
-            components.add(new HeaderComponent(headerName.toLowerCase(), null, true, false));
+            components.add(new HeaderComponent(headerName.toLowerCase(), null, true, false, false));
             return this;
         }
 
@@ -155,7 +155,7 @@ public class SignatureComponents {
          * @see HeaderComponent
          */
         public Builder relatedRequestCanonicalizedHeader(String headerName) {
-            components.add(new HeaderComponent(headerName.toLowerCase(), null, true, true));
+            components.add(new HeaderComponent(headerName.toLowerCase(), null, true, true, false));
             return this;
         }
 
@@ -170,7 +170,7 @@ public class SignatureComponents {
          * @see HeaderComponent
          */
         public Builder dictionaryMember(String headerName, String dictionaryKey) {
-            components.add(new HeaderComponent(headerName.toLowerCase(), Objects.requireNonNull(dictionaryKey), false, false));
+            components.add(new HeaderComponent(headerName.toLowerCase(), Objects.requireNonNull(dictionaryKey), false, false, false));
             return this;
         }
 
@@ -187,7 +187,35 @@ public class SignatureComponents {
          * @see HeaderComponent
          */
         public Builder relatedRequestDictionaryMember(String headerName, String dictionaryKey) {
-            components.add(new HeaderComponent(headerName.toLowerCase(), Objects.requireNonNull(dictionaryKey), false, true));
+            components.add(new HeaderComponent(headerName.toLowerCase(), Objects.requireNonNull(dictionaryKey), false, true, false));
+            return this;
+        }
+
+        /**
+         * Adds a single Binary-wrapped HTTP Field component
+         *
+         * @param headerName Header name
+         * @return This builder
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-binary-wrapped-http-fields">
+         *      Binary-wrapped HTTP Fields</a>
+         */
+        public Builder binaryWrappedHeader(String headerName) {
+            components.add(new HeaderComponent(headerName.toLowerCase(), null, false, false, true));
+            return this;
+        }
+
+        /**
+         * Adds a single Binary-wrapped HTTP Field component for Related request
+         *
+         * @param headerName Header name
+         * @return This builder
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-binary-wrapped-http-fields">
+         *      Binary-wrapped HTTP Fields</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+         *      Request-Response Signature Binding</a>
+         */
+        public Builder relatedRequestBinaryWrappedHeader(String headerName) {
+            components.add(new HeaderComponent(headerName.toLowerCase(), null, false, true, true));
             return this;
         }
 

--- a/src/main/java/com/visma/autopay/http/signature/SignatureContext.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureContext.java
@@ -92,7 +92,7 @@ public class SignatureContext {
      * Returns Signature Context for Related Request
      *
      * @return SignatureContext of Related Request
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-request-response-signature-">
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-request-response-signature-">
      *      Request-Response Signature Binding</a>
      */
     SignatureContext getRelatedRequestContext() {
@@ -178,7 +178,7 @@ public class SignatureContext {
          * @param headerName  HTTP header (field) name
          * @param headerValue Header value
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-fields">HTTP Fields</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-fields">HTTP Fields</a>
          */
         public Builder header(String headerName, Object headerValue) {
             headerName = headerName.toLowerCase();
@@ -212,7 +212,7 @@ public class SignatureContext {
          *
          * @param headers A map of HTTP header names and values
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-http-fields">HTTP Fields</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-http-fields">HTTP Fields</a>
          */
         public Builder headers(Map<String, ?> headers) {
             for (var entry : headers.entrySet()) {

--- a/src/main/java/com/visma/autopay/http/signature/SignatureParameterType.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureParameterType.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 /**
  * Defines types of Signature Parameters
  *
- * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-signature-parameters">Signature Parameters</a>
+ * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-signature-parameters">Signature Parameters</a>
  */
 public enum SignatureParameterType {
     /**

--- a/src/main/java/com/visma/autopay/http/signature/SignatureParameters.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureParameters.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 /**
  * Builder class for constructing Signature Parameters. Used when creating signatures.
  *
- * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-signature-parameters">Signature Parameters</a>
+ * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-signature-parameters">Signature Parameters</a>
  * @see SignatureParameterType
  */
 public class SignatureParameters {

--- a/src/main/java/com/visma/autopay/http/signature/SignatureResult.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureResult.java
@@ -68,7 +68,7 @@ public final class SignatureResult {
      * Returns signature base which can be used for logging or debugging
      *
      * @return Signature Base
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-creating-the-signature-base">
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-creating-the-signature-base">
      *      Creating the Signature Base</a>
      */
     public String getSignatureBase() {

--- a/src/main/java/com/visma/autopay/http/signature/SignatureSigner.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureSigner.java
@@ -47,7 +47,7 @@ final class SignatureSigner {
      *         logging or debugging
      * @throws SignatureException Problems with signature calculation, e.g. missing or malformatted values in Signature Context, problems with the private key.
      *                            For detailed reason call {@link SignatureException#getErrorCode()}.
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-creating-a-signature">Creating a Signature</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-creating-a-signature">Creating a Signature</a>
      */
     static SignatureResult sign(SignatureSpec signatureSpec) throws SignatureException {
         var components = extractUsedComponents(signatureSpec);
@@ -70,7 +70,7 @@ final class SignatureSigner {
      * @param signatureInput   Value of <em>Signature-Input</em> header provided as Structured Inner List
      * @return Signature base to be used for signature creation or verification
      * @throws SignatureException In case of problems with extracting values from the Signature Context, e.g. missing or malformatted HTTP header
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#create-sig-input">Creating the Signature Base</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#create-sig-input">Creating the Signature Base</a>
      */
     static String getSignatureBase(List<Component> components, SignatureContext signatureContext, StructuredInnerList signatureInput)
             throws SignatureException {

--- a/src/main/java/com/visma/autopay/http/signature/SignatureSpec.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureSpec.java
@@ -64,7 +64,7 @@ public class SignatureSpec {
      *         logging or debugging
      * @throws SignatureException Problems with signature calculation, e.g. missing or malformatted values in Signature Context, problems with the private key.
      *                            For detailed reason call {@link SignatureException#getErrorCode()}.
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-creating-a-signature">Creating a Signature</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-creating-a-signature">Creating a Signature</a>
      */
     public SignatureResult sign() throws SignatureException {
         return SignatureSigner.sign(this);
@@ -119,7 +119,7 @@ public class SignatureSpec {
      * Returns signature label
      *
      * @return Signature label
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-signature-labels">Signature Labels</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-signature-labels">Signature Labels</a>
      */
     String getSignatureLabel() {
         return signatureLabel;
@@ -244,7 +244,7 @@ public class SignatureSpec {
          *
          * @param signatureLabel Signature label
          * @return This builder
-         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-signature-labels">Signature Labels</a>
+         * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-signature-labels">Signature Labels</a>
          */
         public Builder signatureLabel(String signatureLabel) {
             this.signatureLabel = signatureLabel;

--- a/src/main/java/com/visma/autopay/http/signature/SignatureVerifier.java
+++ b/src/main/java/com/visma/autopay/http/signature/SignatureVerifier.java
@@ -48,7 +48,7 @@ final class SignatureVerifier {
      * @param verificationSpec Verification specification: parameters, components, context of HTTP request or response, public key supplier, signature label
      * @throws SignatureException Incorrect signature or problems with verification, e.g. missing or malformatted values in Signature Context, problems with the
      *                            public key. For detailed reason call {@link SignatureException#getErrorCode()}.
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-verifying-a-signature">Verifying a Signature</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-verifying-a-signature">Verifying a Signature</a>
      */
     static void verify(VerificationSpec verificationSpec) throws SignatureException {
         new SignatureVerifier(verificationSpec).verify();

--- a/src/main/java/com/visma/autopay/http/signature/VerificationSpec.java
+++ b/src/main/java/com/visma/autopay/http/signature/VerificationSpec.java
@@ -76,7 +76,7 @@ public class VerificationSpec {
      *
      * @throws SignatureException Incorrect signature or problems with verification, e.g. missing or malformatted values in Signature Context, problems with the
      *                            public key. For detailed reason call {@link SignatureException#getErrorCode()}.
-     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-10.html#name-verifying-a-signature">Verifying a Signature</a>
+     * @see <a href="https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-verifying-a-signature">Verifying a Signature</a>
      */
     public void verify() throws SignatureException {
         SignatureVerifier.verify(this);

--- a/src/test/java/com/visma/autopay/http/signature/SignatureContextTest.java
+++ b/src/test/java/com/visma/autopay/http/signature/SignatureContextTest.java
@@ -37,13 +37,13 @@ class SignatureContextTest {
         // setup
         var headers = Map.of(
                 "header-1", List.of("one", "two"),
-                "header-2", Arrays.asList(null, "", "xx", "yy")
+                "header-2", Arrays.asList("", "xx", "yy")
         );
 
         // execute
         var signatureContext = SignatureContext.builder().headers(headers).build();
 
         // verify
-        assertThat(signatureContext.getHeaders()).containsOnly(entry("header-1", "one, two"), entry("header-2", "xx, yy"));
+        assertThat(signatureContext.getHeaders()).containsOnly(entry("header-1", List.of("one", "two")), entry("header-2", List.of("", "xx", "yy")));
     }
 }

--- a/src/test/java/com/visma/autopay/http/signature/SignatureSpecificationTest.java
+++ b/src/test/java/com/visma/autopay/http/signature/SignatureSpecificationTest.java
@@ -145,6 +145,7 @@ class SignatureSpecificationTest {
         var signatureComponents = SignatureComponents.builder()
                 .authority()
                 .header("Content-Digest")
+                .queryParam("Pet")
                 .build();
         var signatureSpec = SignatureSpec.builder()
                 .signatureLabel(signatureLabel)
@@ -157,7 +158,7 @@ class SignatureSpecificationTest {
                 .algorithm(algorithm)
                 .publicKey(ObjectMother.getRsaPssPublicKey())
                 .build();
-        var expectedSignatureInput = "sig-b22=(\"@authority\" \"content-digest\");created=1618884473;keyid=\"test-key-rsa-pss\"";
+        var expectedSignatureInput = "sig-b22=(\"@authority\" \"content-digest\" \"@query-param\";name=\"Pet\");created=1618884473;keyid=\"test-key-rsa-pss\"";
 
         // execute
         var signatureResult = signatureSpec.sign();
@@ -170,11 +171,12 @@ class SignatureSpecificationTest {
         verificationSpec.verify();
 
         // verify example signature
-        var validSignature = "sig-b22=:Fee1uy9YGZq5UUwwYU6vz4dZNvfw3GYrFl1L6YlVIyUMuWswWDNSvql4dVtS" +
-                "eidYjYZUm7SBCENIb5KYy2ByoC3bI+7gydd2i4OAT5lyDtmeapnAa8uP/b9xUpg+VSPElbBs6JWBIQsd+n" +
-                "MdHDe+ls/IwVMwXktC37SqsnbNyhNp6kcvcWpevjzFcD2VqdZleUz4jN7P+W5A3wHiMGfIjIWn36KXNB+R" +
-                "KyrlGnIS8yaBBrom5rcZWLrLbtg6VlrH1+/07RV+kgTh/l10h8qgpl9zQHu7mWbDKTq0tJ8K4ywcPoC4s2" +
-                "I4rU88jzDKDGdTTQFZoTVZxZmuTM1FvHfzIw==:";
+        var validSignature = "sig-b22=:W2kxR52X0tXN9u7yjyPeWa0T3D0SVG8KkPo+lOWyb2TGdLz"
+                + "ixWjUlbehjnNhzA+wFWnE6+hdKH8KR6Z9FvsxCc+44XrqxzT7Vcsror5SjMyfx6Nq"
+                + "tELklj1u2L4JovANI80BSoVobSoc+v9NRVWJZU7WAVow8H2CucCcv2cy1tKFCTMyc"
+                + "m9LQrIz63Tg5tcGWj64b12nmwj9TwwkCygfz0MTyIytjYLVzKw7mXpL4jGFZ5lsw2"
+                + "VT2eB3qpF2d/Psy0p1heKhrkz9uvKeCoj+P5QjLMS4eirHDqpKqe9YmCaMsJAUYSU"
+                + "M86qC8qO6vMQhTMegTkEe25DquVcTiOAEAw==:";
         verificationSpec = getVerificationSpec(signatureLabel, keyId, publicKeyInfo, expectedSignatureInput, validSignature);
         verificationSpec.verify();
     }


### PR DESCRIPTION
This PR is just for test - it adds support for [Binary-wrapped HTTP Fields](https://www.ietf.org/archive/id/draft-ietf-httpbis-message-signatures-11.html#name-binary-wrapped-http-fields)

Please take a close look at [README.md](https://github.com/Visma-AutoPay/http-signatures/blob/main/README.md) and  [Jenkinsfile](https://github.com/Visma-AutoPay/http-signatures/blob/main/Jenkinsfile) in the `main` branch and [Javadoc](https://visma-autopay.github.io/http-signatures/) at GitHub pages.