### PR TITLE
Verify signature only if a public key is passed

### DIFF
--- a/src/main/java/net/visma/autopay/http/signature/SignatureVerifier.java
+++ b/src/main/java/net/visma/autopay/http/signature/SignatureVerifier.java
@@ -67,17 +67,20 @@ final class SignatureVerifier {
         verifyRequired();
         verifyForbidden();
         verifyExpiration();
-        var givenSignature = getSignature();
-        var signatureComponents = getComponents();
-        var signatureBase = SignatureSigner.getSignatureBase(signatureComponents, signatureContext, signatureInput);
 
-        var publicKeyInfo = getPublicKeyInfo();
-        var algorithm = getAlgorithm(publicKeyInfo);
-        var publicKey = publicKeyInfo.getPublicKey(algorithm.getKeyAlgorithm());
+        if (verifySignature()) {
+            var givenSignature = getSignature();
+            var signatureComponents = getComponents();
+            var signatureBase = SignatureSigner.getSignatureBase(signatureComponents, signatureContext, signatureInput);
 
-        if (!DataVerifier.verify(signatureBase, givenSignature, publicKey, algorithm)) {
-            throw new SignatureException(ErrorCode.INCORRECT_SIGNATURE, "Provided signature different from computed one.\nUsed algorithm: "
-                    + algorithm.getIdentifier() + "\nSignature base:\n" + signatureBase);
+            var publicKeyInfo = getPublicKeyInfo();
+            var algorithm = getAlgorithm(publicKeyInfo);
+            var publicKey = publicKeyInfo.getPublicKey(algorithm.getKeyAlgorithm());
+
+            if (!DataVerifier.verify(signatureBase, givenSignature, publicKey, algorithm)) {
+                throw new SignatureException(ErrorCode.INCORRECT_SIGNATURE, "Provided signature different from computed one.\nUsed algorithm: "
+                        + algorithm.getIdentifier() + "\nSignature base:\n" + signatureBase);
+            }
         }
     }
 
@@ -94,6 +97,10 @@ final class SignatureVerifier {
         return algorithm;
     }
 
+    private boolean verifySignature() {
+        return verificationSpec.getPublicKeyGetter() != null;
+    }
+    
     private PublicKeyInfo getPublicKeyInfo() throws SignatureException {
         try {
             return verificationSpec.getPublicKeyGetter().apply(signatureParameters.getKeyId());


### PR DESCRIPTION
In case the public key is not passed, verification must not be done. This is useful in cases where the public key is obtained via introspection (GNAP), and verification other than signature avoids an introspection call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated signature validation to handle cases where no public key is provided, avoiding unnecessary verification failures.
  * Signature checks now run only when the required key information is available, improving reliability of authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->