### PR TITLE
AUTOPAY-38262 kb auto load claude

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,6 @@ KB at `03-products/01-autopay/09-codebases/15-http-signatures.md` — read
 `15-http-signatures-summary.md` first. Not duplicated here; update the KB doc rather than re-adding it
 to this file.
 
-Before opening a PR, check whether the change needs a KB update rather than deciding by hand. In Claude
-Code that is `/kb-check`; with any other tool, apply the same gate directly from the KB's
-`0-meta/durability-gate.md`.
+Before opening a PR, check whether the change needs a KB update rather than deciding by hand — apply
+the gate in the KB's `0-meta/durability-gate.md`. In Claude Code the optional `/kb-check` skill
+automates exactly that; installing it is not required.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ KB at `03-products/01-autopay/09-codebases/15-http-signatures.md` — read
 `15-http-signatures-summary.md` first. Not duplicated here; update the KB doc rather than re-adding it
 to this file.
 
-Before opening a PR, check whether the change needs a KB update rather than deciding by hand — apply
-the gate in the KB's `0-meta/durability-gate.md`. In Claude Code the optional `/kb-check` skill
-automates exactly that; installing it is not required.
+Before opening a PR, check whether the change needs a KB update rather than deciding by hand. Follow
+the procedure in the KB's `skills/kb-check/SKILL.md`: it applies `0-meta/durability-gate.md` across
+every repo the change touches, which the gate alone cannot do. In Claude Code it installs as
+`/kb-check` — installing is optional, running the check is not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,21 @@
 # CLAUDE.md
 
+## Knowledge Base
+
+Architecture, conventions, domain model and API contracts for AutoPay live in the
+`autopay-knowledgebase` repo, normally cloned alongside this one. Locate it via `$AUTOPAY_KB`, else
+`../autopay-knowledgebase`, else by walking up parent directories — then read its `CLAUDE.shared.md`
+**before searching the KB**, and follow the routing and reading rules there. Its routing table names
+the right page directly; grepping the KB blind is slower and pulls in heavy docs you don't need.
+
+**This repo has no KB codebase doc yet** (`09-codebases/15-http-signatures.md` is in progress under
+AUTOPAY-38296). Until it lands, the material below is the authoritative description of this library and
+is deliberately *not* trimmed. Once the KB doc exists, move the duplicated parts there and cut this file
+down to the pointer.
+
+To check whether a change you just made needs a KB update, run `/kb-check` rather than deciding by
+hand.
+
 ## Project Overview
 
 This is a Java library implementing the IETF HTTP Message Signatures specification (RFC 9421), along with Digest Fields (RFC 9530) and Structured Field Values for HTTP (RFC 8941). The library provides high-level interfaces for creating and verifying HTTP signatures for end-to-end integrity and authenticity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,12 +3,12 @@
 ## Knowledge Base
 
 Architecture, conventions, domain model and API contracts for AutoPay live in the
-`autopay-knowledgebase` repo, normally cloned alongside this one. Use the first of `$AUTOPAY_KB`,
-`../autopay-knowledgebase`, or a parent directory that **actually contains `CLAUDE.shared.md`** — a set
-but stale `$AUTOPAY_KB` is a hint, not an answer, so keep going down the list. Read that file **before
-searching the KB** and follow its routing and reading rules: the routing table names the right page
-directly, and grepping blind is slower and pulls in heavy docs you don't need. If no candidate has it,
-say the KB is unavailable rather than answering from guesswork.
+`autopay-knowledgebase` repo, normally cloned alongside this one. Locate it by checking, in order,
+`$AUTOPAY_KB`, then `../autopay-knowledgebase`, then each parent directory. **A candidate only counts
+if it contains a readable `CLAUDE.shared.md`** — skip any that does not, including a set but stale
+`$AUTOPAY_KB`. Read that file **before searching the KB** and follow its routing and reading rules: the
+routing table names the right page directly, and grepping blind is slower and pulls in heavy docs you
+don't need. If no candidate has it, say the KB is unavailable rather than answering from guesswork.
 
 Consult it before planning, implementing, debugging or reviewing, and check it for prior art before
 inventing a new pattern.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,117 +13,15 @@ don't need. If no candidate has it, say the KB is unavailable rather than answer
 Consult it before planning, implementing, debugging or reviewing, and check it for prior art before
 inventing a new pattern.
 
-**This repo has no KB codebase doc yet** (`09-codebases/15-http-signatures.md` is in progress under
-AUTOPAY-38296). Until it lands, the material below is the authoritative description of this library and
-is deliberately *not* trimmed. Once the KB doc exists, move the duplicated parts there and cut this file
-down to the pointer.
+This repo is a **public, MIT-licensed library on Java 11 with zero compile dependencies** — not a
+deployed service, and a deliberate exception to the Java 21 baseline. Treat anything written here as
+externally visible, and do not add a compile dependency: both are breaking changes for consumers. Its
+package layout, the builder-based signature/verification spec pattern, the structured-field type
+hierarchy, the ECDSA P1363 gotcha, consumer pins and the release-to-Central flow are documented in the
+KB at `03-products/01-autopay/09-codebases/15-http-signatures.md` — read
+`15-http-signatures-summary.md` first. Not duplicated here; update the KB doc rather than re-adding it
+to this file.
 
 Before opening a PR, check whether the change needs a KB update rather than deciding by hand. In Claude
 Code that is `/kb-check`; with any other tool, apply the same gate directly from the KB's
 `0-meta/durability-gate.md`.
-
-## Project Overview
-
-This is a Java library implementing the IETF HTTP Message Signatures specification (RFC 9421), along with Digest Fields (RFC 9530) and Structured Field Values for HTTP (RFC 8941). The library provides high-level interfaces for creating and verifying HTTP signatures for end-to-end integrity and authenticity.
-
-**Requirements:** Java 11 or newer. No compile dependencies.
-
-## Architecture
-
-### Package Structure
-
-The codebase is organized into three main functional areas:
-
-1. **`net.visma.autopay.http.signature`** - HTTP Message Signatures (RFC 9421)
-2. **`net.visma.autopay.http.digest`** - Digest Fields (RFC 9530)
-3. **`net.visma.autopay.http.structured`** - Structured Field Values (RFC 8941)
-
-### Signature Package Architecture
-
-The signature package follows a builder-based specification pattern with clear separation between:
-
-**Specification Objects (immutable):**
-- `SignatureSpec` - Complete specification for creating a signature (components, parameters, context, private key, label)
-- `VerificationSpec` - Complete specification for verifying a signature (required/forbidden parameters, required components, context, public key getter, label/tag, time limits)
-- `SignatureComponents` - Defines which HTTP message parts to include (headers, derived components like @method, @path, @authority)
-- `SignatureParameters` - Metadata for signatures (created, expires, nonce, keyid, algorithm, tag)
-- `SignatureContext` - Container for actual HTTP message values (method, URI, status, headers, trailers, related request context)
-
-**Core Operations:**
-- `SignatureSigner` - Low-level signing operations
-- `SignatureVerifier` - Low-level verification operations
-- `DataSigner` / `DataVerifier` - Handle cryptographic operations using Java security providers
-
-**Supporting Classes:**
-- `Component` / `HeaderComponent` / `DerivedComponent` - Individual signature component representations
-- `SignatureAlgorithm` / `SignatureKeyAlgorithm` - Algorithm definitions (RSA, ECDSA, EdDSA, HMAC)
-- `PublicKeyInfo` - Encapsulates public key with algorithm information
-- `SignatureResult` - Output containing signature headers and base string
-
-### Structured Fields Architecture
-
-Structured fields implement RFC 8941 with a type hierarchy:
-
-**Base Types:**
-- `StructuredItem` - Abstract base for all items (has optional parameters)
-- `StructuredField` - Marker interface for top-level fields (Lists and Dictionaries)
-
-**Concrete Item Types:**
-- `StructuredInteger` (stores `long`)
-- `StructuredDecimal` (stores `BigDecimal`)
-- `StructuredString` (stores `String`)
-- `StructuredToken` (stores `String`)
-- `StructuredBytes` (stores `byte[]`)
-- `StructuredBoolean` (stores `boolean`)
-
-**Collection Types:**
-- `StructuredList` - Top-level list (List&lt;StructuredItem&gt;)
-- `StructuredInnerList` - Nested list within a list or dictionary
-- `StructuredDictionary` - Top-level dictionary (LinkedHashMap&lt;String, StructuredItem&gt;)
-- `StructuredParameters` - Parameters attached to items (LinkedHashMap&lt;String, StructuredItem&gt;)
-
-**Utilities:**
-- `StructuredParser` - Parses RFC 8941 serialized strings into structured objects
-- `CharacterValidator` - Validates characters according to RFC 8941 rules
-
-### Digest Package
-
-Simple utility classes for computing and verifying Content-Digest headers:
-- `DigestCalculator` - Computes SHA-256 or SHA-512 digests of request/response bodies
-- `DigestVerifier` - Verifies digest headers against actual content
-- `DigestAlgorithm` - Enum of supported algorithms (SHA_256, SHA_512)
-
-## Key Design Patterns
-
-### Security Provider Abstraction
-The library uses Java's default security providers but allows third-party providers (like Bouncy Castle) to be registered. For ECDSA signatures, the library specifically uses P1363 format algorithms (e.g., `SHA256withECDSAinP1363Format`) as required by RFC 9421.
-
-### Exception Handling
-- `SignatureException` - Thrown for all signature creation/verification failures
-- `DigestException` - Thrown for digest computation/verification failures
-- `StructuredException` - Thrown for structured field parsing/serialization failures
-
-All exceptions extend from `Exception` (checked exceptions), requiring explicit handling.
-
-## Testing
-
-- Test utilities include `ObjectMother` for test data generation
-- Specification tests in `net.visma.autopay.http.structured.spec` use JSON test vectors from RFC 8941
-- Bouncy Castle provider is available in test scope for testing with third-party security providers
-
-## Common Development Scenarios
-
-### Adding Support for New Signature Algorithms
-1. Add algorithm to `SignatureAlgorithm` enum
-2. Update `SignatureKeyAlgorithm` to map key algorithm
-3. Add tests in `DataSignerTest` and `DataVerifierTest`
-4. Consider provider compatibility (especially for ECDSA P1363 format)
-
-### Adding New Derived Components
-1. Add component type to `DerivedComponentType` enum
-2. Update `ComponentFactory` to handle extraction from `SignatureContext`
-3. Add builder methods to `SignatureComponents.Builder`
-4. Add tests covering serialization and extraction
-
-### Modifying Structured Field Parsing
-Changes to `StructuredParser` should maintain RFC 8941 compliance. Run the specification tests in `StructuredSpecificationTest` which use official test vectors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,18 +3,24 @@
 ## Knowledge Base
 
 Architecture, conventions, domain model and API contracts for AutoPay live in the
-`autopay-knowledgebase` repo, normally cloned alongside this one. Locate it via `$AUTOPAY_KB`, else
-`../autopay-knowledgebase`, else by walking up parent directories — then read its `CLAUDE.shared.md`
-**before searching the KB**, and follow the routing and reading rules there. Its routing table names
-the right page directly; grepping the KB blind is slower and pulls in heavy docs you don't need.
+`autopay-knowledgebase` repo, normally cloned alongside this one. Use the first of `$AUTOPAY_KB`,
+`../autopay-knowledgebase`, or a parent directory that **actually contains `CLAUDE.shared.md`** — a set
+but stale `$AUTOPAY_KB` is a hint, not an answer, so keep going down the list. Read that file **before
+searching the KB** and follow its routing and reading rules: the routing table names the right page
+directly, and grepping blind is slower and pulls in heavy docs you don't need. If no candidate has it,
+say the KB is unavailable rather than answering from guesswork.
+
+Consult it before planning, implementing, debugging or reviewing, and check it for prior art before
+inventing a new pattern.
 
 **This repo has no KB codebase doc yet** (`09-codebases/15-http-signatures.md` is in progress under
 AUTOPAY-38296). Until it lands, the material below is the authoritative description of this library and
 is deliberately *not* trimmed. Once the KB doc exists, move the duplicated parts there and cut this file
 down to the pointer.
 
-To check whether a change you just made needs a KB update, run `/kb-check` rather than deciding by
-hand.
+Before opening a PR, check whether the change needs a KB update rather than deciding by hand. In Claude
+Code that is `/kb-check`; with any other tool, apply the same gate directly from the KB's
+`0-meta/durability-gate.md`.
 
 ## Project Overview
 


### PR DESCRIPTION
Pointer only. This repo has no 09-codebases doc — 15-http-signatures.md is being added under AUTOPAY-38296 — so there is nothing to verify content against and nothing may be deleted yet. The existing 107 lines stay as the authoritative description, with a note to trim once the KB doc lands.

The pointer is additive, so it does not wait on that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance with concise instructions for locating and consulting the AutoPay knowledge base.
  * Added guidance for validating shared instructions, checking compatibility constraints, finding relevant documentation, and completing the pre-PR durability review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->